### PR TITLE
feat: add Railway deployment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.pytest_cache
+.venv
+__pycache__
+*.pyc
+artifacts
+.env

--- a/.env.example
+++ b/.env.example
@@ -2,16 +2,22 @@
 APP_ENV=local
 APP_LOG_LEVEL=INFO
 
-# Source
+# Source scraper target
 SOURCE_URL=https://vpn.maximkatz.com/
 SOURCE_TIMEZONE=UTC
+
+# Intended scheduler windows (metadata for ops/docs)
 SCRAPE_TIMES_UTC=00:00,06:00,12:00,18:00
 DAILY_POST_TIME_UTC=19:00
 
-# Database (PostgreSQL)
+# Database (required for bot, scrape-save, generate-chart, post-daily)
 DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/vpn_rating_watcher
 
-# Telegram
+# Telegram (required for bot and post-daily)
 TELEGRAM_BOT_TOKEN=
+
+# Optional legacy single chat id
 TELEGRAM_CHAT_ID=
+
+# Optional comma-separated chat IDs for daily bootstrap
 TELEGRAM_DEFAULT_CHAT_IDS=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md /app/
+COPY src /app/src
+COPY alembic /app/alembic
+COPY alembic.ini /app/alembic.ini
+
+RUN pip install --upgrade pip \
+    && pip install . \
+    && python -m playwright install --with-deps chromium
+
+CMD ["vrw", "bot"]

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,53 @@
+# OPERATIONS
+
+## Scraper flow
+
+1. Run `vrw scrape-save`.
+2. The scraper loads the rendered source page with Playwright Chromium.
+3. Parsed rows are normalized and hashed.
+4. Snapshot + result rows are written to PostgreSQL transactionally.
+5. If the latest hash is unchanged, the run returns `no_change` and avoids duplicates.
+
+## Chart generation flow
+
+1. Run `vrw generate-chart` (explicitly or from an operator workflow).
+2. Historical snapshot results are aggregated by day.
+3. A PNG heatmap is written to `artifacts/charts/...`.
+4. Chart metadata is stored in `generated_chart` for bot/posting retrieval.
+
+## Bot flow
+
+1. Run `vrw bot` as a long-running process.
+2. Bot polls Telegram for commands.
+3. Incoming chats are upserted to `telegram_chat` and marked active.
+4. Commands send chart/snapshot responses from DB-backed data.
+
+## Daily posting flow
+
+1. Run `vrw post-daily` once per day.
+2. Command verifies today's chart exists.
+3. Active chats are resolved from `telegram_chat` plus optional
+   `TELEGRAM_DEFAULT_CHAT_IDS` bootstrap values.
+4. Chart is posted once per chat per UTC day (`last_posted_date` guarded).
+
+## Recommended Railway setup
+
+Create three Railway services from the same repository/image:
+
+1. **vrw-bot** (worker)
+   - Command: `vrw bot`
+   - Schedule: none (always on)
+2. **vrw-scrape** (cron)
+   - Command: `vrw scrape-save`
+   - Schedule: `0 */6 * * *`
+3. **vrw-post-daily** (cron)
+   - Command: `vrw post-daily`
+   - Schedule: `0 19 * * *`
+
+Shared config:
+
+- Attach Railway PostgreSQL and set `DATABASE_URL` for all services.
+- Set `SOURCE_URL` and `SOURCE_TIMEZONE`.
+- Set `TELEGRAM_BOT_TOKEN` for bot and daily posting jobs.
+- Optionally set `TELEGRAM_DEFAULT_CHAT_IDS` to seed chat targets.
+- Use included Dockerfile so Playwright Chromium + deps are preinstalled.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Current implementation scope:
 - ✅ Historical heatmap chart generation (PNG)
 - ✅ Telegram bot polling commands (`/start`, `/help`, `/today`, `/chart`, `/last`)
 - ✅ Daily Telegram posting job command (`vrw post-daily`)
-- ⛔ No scheduler wiring yet (cron/Railway not implemented in this phase)
+- ✅ Railway-ready deployment and scheduler wiring documentation
 
 ## Local setup
 
@@ -149,6 +149,69 @@ GitHub Actions runs on every `push` and `pull_request`:
 
 CI scraper smoke test is deterministic: it uses static HTML with Playwright `page.set_content(...)` rather than the live site.
 
+## Railway deployment
+
+This repository includes a Railway-ready `Dockerfile` and `railway.json`.
+
+### 1) Create services/jobs
+
+Use one repo and create three Railway services:
+
+1. **Bot service** (long-running worker)
+   - Start command: `vrw bot`
+2. **Scraper cron job**
+   - Start command: `vrw scrape-save`
+   - Schedule: `0 */6 * * *` (4 times/day, every 6 hours UTC)
+3. **Daily posting cron job**
+   - Start command: `vrw post-daily`
+   - Schedule: `0 19 * * *` (1 time/day, 19:00 UTC)
+
+Railway cron schedules are configured in the Railway UI per service/job.
+
+### 2) Attach PostgreSQL
+
+1. Add a Railway PostgreSQL service.
+2. Reference its connection string in `DATABASE_URL` for each service.
+3. Run migrations before first production run:
+
+```bash
+alembic upgrade head
+```
+
+### 3) Set environment variables
+
+Set these in Railway for all services unless noted:
+
+- `APP_ENV=production`
+- `APP_LOG_LEVEL=INFO`
+- `DATABASE_URL=<railway postgres url>`
+- `SOURCE_URL=https://vpn.maximkatz.com/`
+- `SOURCE_TIMEZONE=UTC`
+- `TELEGRAM_BOT_TOKEN=<required for bot and post-daily>`
+- `TELEGRAM_DEFAULT_CHAT_IDS=<optional comma-separated chat IDs>`
+
+Optional scheduler metadata vars (informational defaults in app):
+
+- `SCRAPE_TIMES_UTC=00:00,06:00,12:00,18:00`
+- `DAILY_POST_TIME_UTC=19:00`
+
+### 4) Playwright dependencies on Railway
+
+The included Docker image installs Chromium and required system libraries with:
+
+```bash
+python -m playwright install --with-deps chromium
+```
+
+No extra apt packages are needed in Railway when using this Dockerfile.
+
+### 5) Runtime behavior and env-var failure boundaries
+
+- `vrw bot` requires `TELEGRAM_BOT_TOKEN` and `DATABASE_URL`.
+- `vrw scrape-save` requires `DATABASE_URL` (and browser dependencies).
+- `vrw post-daily` requires `DATABASE_URL` and `TELEGRAM_BOT_TOKEN`.
+- `vrw scrape` can run without DB credentials.
+
 ## Telegram bot commands
 
 Set in `.env`:
@@ -167,4 +230,4 @@ Notes:
 - Incoming command chats are upserted into `telegram_chat` (`chat_id`, `chat_type`, `title`, `is_active`, `last_posted_date`).
 - Bot command handling is polling-based (`vrw bot`).
 - If chart metadata exists but the PNG is missing on disk, the bot replies with a clear error message.
-- Daily posting scheduler is intentionally not implemented yet; use `vrw post-daily` from external scheduler later.
+- Use Railway cron jobs (documented above) to run `vrw scrape-save` and `vrw post-daily`.

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "vrw bot",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
### Motivation
- Prepare the project to run on Railway with a long-running bot process and two scheduled jobs (scraper and daily posting). 
- Ensure Playwright browser dependencies are installed reliably in a containerized Railway build. 
- Provide clear operator documentation for setting up services, cron schedules, and required environment variables.

### Description
- Added a `Dockerfile` that installs the package and runs `python -m playwright install --with-deps chromium` so Railway builds include Chromium and required deps. 
- Added `railway.json` and `.dockerignore`, and created a default container `CMD` for the long-running worker using `vrw bot`. 
- Added `OPERATIONS.md`, updated `README.md` with a Railway section that maps three Railway services/jobs (`vrw bot`, `vrw scrape-save`, `vrw post-daily`) to explicit cron schedules, and clarified Playwright and Postgres instructions. 
- Updated `.env.example` to document required/optional env vars (Postgres, Telegram tokens, default chat IDs, and scheduler metadata).

### Testing
- Ran `ruff check .` and it passed with no issues. 
- Attempted to run `pytest -q tests/test_smoke.py` in this environment but test collection failed due to a missing local test dependency (`typer`), which prevented running the suite here. 
- The Dockerfile and Railway config were added and validated for syntax and inclusion in the repo; runtime verification should be performed in Railway or a matching container environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9bee1dd50832e9cc96230e1cf8a94)