### PR TITLE
fix: make chart date filtering PostgreSQL-safe

### DIFF
--- a/src/vpn_rating_watcher/charts/service.py
+++ b/src/vpn_rating_watcher/charts/service.py
@@ -110,8 +110,6 @@ def query_daily_latest_scores(
     source_name: str,
 ) -> list[DailyScoreRow]:
     snapshot_day = func.date(Snapshot.fetched_at)
-    start_day = start_date.isoformat()
-    end_day = end_date.isoformat()
     ranked = (
         select(
             Vpn.name.label("vpn_name"),
@@ -127,7 +125,7 @@ def query_daily_latest_scores(
         .select_from(VpnSnapshotResult)
         .join(Snapshot, Snapshot.id == VpnSnapshotResult.snapshot_id)
         .join(Vpn, Vpn.id == VpnSnapshotResult.vpn_id)
-        .where(and_(snapshot_day >= start_day, snapshot_day <= end_day))
+        .where(and_(snapshot_day >= start_date, snapshot_day <= end_date))
     )
 
     if _source_filter(source_name):

--- a/tests/test_chart_aggregation.py
+++ b/tests/test_chart_aggregation.py
@@ -3,11 +3,26 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 
 from sqlalchemy import create_engine
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Session
 
 from vpn_rating_watcher.charts.service import query_daily_latest_scores
 from vpn_rating_watcher.db.base import Base
 from vpn_rating_watcher.db.models import Snapshot, Vpn, VpnSnapshotResult
+
+
+class _ExecuteResult:
+    def all(self) -> list[tuple[str, str, int]]:
+        return []
+
+
+class _CapturingSession:
+    def __init__(self) -> None:
+        self.stmt = None
+
+    def execute(self, stmt):  # noqa: ANN001
+        self.stmt = stmt
+        return _ExecuteResult()
 
 
 def _session() -> Session:
@@ -160,3 +175,26 @@ def test_query_daily_latest_scores_filters_source_name() -> None:
 
         assert live_rows[0].score == 32
         assert mixed_rows[0].score == 36
+
+
+def test_query_daily_latest_scores_binds_date_params_for_postgresql() -> None:
+    session = _CapturingSession()
+    start = date(2026, 3, 1)
+    end = date(2026, 3, 30)
+
+    rows = query_daily_latest_scores(
+        session=session,
+        start_date=start,
+        end_date=end,
+        source_name="mixed",
+    )
+    assert rows == []
+    assert session.stmt is not None
+
+    compiled = session.stmt.compile(dialect=postgresql.dialect())
+    date_params = [value for value in compiled.params.values() if isinstance(value, date)]
+
+    assert start in date_params
+    assert end in date_params
+    assert start.isoformat() not in compiled.params.values()
+    assert end.isoformat() not in compiled.params.values()


### PR DESCRIPTION
### Motivation
- SQL DATE values were being compared to ISO-formatted strings in `query_daily_latest_scores()`, which works on SQLite but can fail on PostgreSQL during SQL execution.
- The intent is to keep the existing latest-per-day and source-filtering behavior while making the predicate PostgreSQL-safe.

### Description
- Compare `func.date(Snapshot.fetched_at)` directly to Python `date` objects (`start_date` / `end_date`) instead of ISO strings in `query_daily_latest_scores()` (remove `isoformat()` usage). 
- Add a regression test `test_query_daily_latest_scores_binds_date_params_for_postgresql` that captures the generated statement, compiles it with the PostgreSQL dialect, and asserts that the bound parameters are `date` objects and not ISO strings. 
- Introduce small test helpers `_CapturingSession` and `_ExecuteResult` to inspect the produced statement without a DB connection. 
- Tidy imports and satisfy `ruff` (line-length and style) for the modified files.

### Testing
- Ran `ruff check src/vpn_rating_watcher/charts/service.py tests/test_chart_aggregation.py`, and it passed.
- Attempted `pytest -q tests/test_chart_aggregation.py`, but test collection failed in this runner because `sqlalchemy` is not installed in the environment (external dependency), so the full pytest run could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9d49b754c832e9efb0e77c015a1c3)