### PR TITLE
feat: replace heatmap with historical line chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Current implementation scope:
 - ✅ Database persistence layer for snapshots and VPN row results
 - ✅ Idempotent save behavior (`no_change` on same latest hash)
 - ✅ Historical backfill import from manual CSV transcription
-- ✅ Historical heatmap chart generation (PNG)
+- ✅ Historical multi-line score chart generation (PNG)
 - ✅ Telegram bot polling commands (`/start`, `/help`, `/today`, `/chart`, `/last`)
 - ✅ Daily Telegram posting job command (`vrw post-daily`)
 - ✅ Railway-ready deployment and scheduler wiring documentation
@@ -60,7 +60,7 @@ Import historical data from CSV:
 vrw import-csv --path examples/history_import.csv
 ```
 
-Generate historical heatmap chart (default last 30 days from latest available snapshot):
+Generate historical score line chart (default last 30 days from latest available snapshot):
 
 ```bash
 vrw generate-chart --days 30

--- a/src/vpn_rating_watcher/bot/service.py
+++ b/src/vpn_rating_watcher/bot/service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from sqlalchemy import Select, desc, select
 from sqlalchemy.orm import Session, sessionmaker
 
-from vpn_rating_watcher.charts.service import HEATMAP_CHART_TYPE
+from vpn_rating_watcher.charts.service import LINE_CHART_TYPE
 from vpn_rating_watcher.db.models import (
     GeneratedChart,
     Snapshot,
@@ -74,7 +74,7 @@ def upsert_telegram_chat(
 def _latest_chart_query() -> Select[tuple[GeneratedChart]]:
     return (
         select(GeneratedChart)
-        .where(GeneratedChart.chart_type == HEATMAP_CHART_TYPE)
+        .where(GeneratedChart.chart_type == LINE_CHART_TYPE)
         .order_by(
             desc(GeneratedChart.chart_date),
             desc(GeneratedChart.created_at),

--- a/src/vpn_rating_watcher/charts/service.py
+++ b/src/vpn_rating_watcher/charts/service.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib import colormaps
 from sqlalchemy import Select, and_, desc, func, select
 from sqlalchemy.orm import Session
 
@@ -17,7 +16,7 @@ matplotlib.use("Agg")
 
 MAIN_LIVE_SOURCE_NAME = "maximkatz"
 MIXED_SOURCE_NAME = "mixed"
-HEATMAP_CHART_TYPE = "historical_heatmap"
+LINE_CHART_TYPE = "historical_line_chart"
 
 
 @dataclass(slots=True)
@@ -165,23 +164,20 @@ def _build_dates(start_date: date, end_date: date) -> list[date]:
     return dates
 
 
-def _output_path(
-    output: str | None,
-    source_name: str,
-    start_date: date,
-    end_date: date,
-) -> Path:
+def _output_path(output: str | None, source_name: str, start_date: date, end_date: date) -> Path:
     if output:
         path = Path(output)
     else:
-        filename = f"heatmap_{source_name}_{start_date.isoformat()}_{end_date.isoformat()}.png"
+        filename = f"linechart_{source_name}_{start_date.isoformat()}_{end_date.isoformat()}.png"
         path = Path("artifacts/charts") / filename
     path.parent.mkdir(parents=True, exist_ok=True)
     return path
 
 
 def _matrix_from_rows(
-    rows: list[DailyScoreRow], dates: list[date], top_n: int | None
+    rows: list[DailyScoreRow],
+    dates: list[date],
+    top_n: int | None,
 ) -> tuple[np.ndarray, list[str]]:
     if top_n is not None and top_n <= 0:
         raise ValueError("--top-n must be greater than zero")
@@ -208,7 +204,18 @@ def _matrix_from_rows(
     return matrix, vpn_names
 
 
-def _render_heatmap(
+def _effective_chart_dates(
+    rows: list[DailyScoreRow], *, fallback_start: date, fallback_end: date
+) -> list[date]:
+    if not rows:
+        return _build_dates(start_date=fallback_start, end_date=fallback_end)
+
+    first_data_date = min(row.snapshot_date for row in rows)
+    last_data_date = max(row.snapshot_date for row in rows)
+    return _build_dates(start_date=first_data_date, end_date=last_data_date)
+
+
+def _render_line_chart(
     *,
     matrix: np.ndarray,
     vpn_names: list[str],
@@ -223,42 +230,42 @@ def _render_heatmap(
     fig.patch.set_facecolor("#0f111a")
     ax.set_facecolor("#0f111a")
 
-    cmap = colormaps["viridis"].copy()
-    cmap.set_bad(color="#2f3542")
-
-    im = ax.imshow(matrix, aspect="auto", interpolation="nearest", cmap=cmap)
-
     ax.set_xticks(np.arange(len(dates)))
-    ax.set_xticklabels([day.isoformat() for day in dates], rotation=45, ha="right", color="white")
-    ax.set_yticks(np.arange(len(vpn_names)))
-    ax.set_yticklabels(vpn_names, color="white")
+    ax.set_xticklabels(
+        [day.isoformat() for day in dates], rotation=45, ha="right", color="white"
+    )
+
+    x_values = np.arange(len(dates))
+    for idx, vpn_name in enumerate(vpn_names):
+        ax.plot(x_values, matrix[idx], marker="o", linewidth=1.8, markersize=3, label=vpn_name)
 
     ax.set_xlabel("Date", color="white")
-    ax.set_ylabel("VPN", color="white")
+    ax.set_ylabel("Score", color="white")
+    ax.set_ylim(0, 36)
 
     generated_at = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     ax.set_title(
-        f"VPN Historical Scores Heatmap ({source_name})\nGenerated: {generated_at}",
+        f"VPN Historical Scores ({source_name})\nGenerated: {generated_at}",
         color="white",
         fontsize=12,
         pad=14,
     )
 
-    cbar = fig.colorbar(im, ax=ax)
-    cbar.set_label("Score (numerator from result_raw)", color="white")
-    cbar.ax.yaxis.set_tick_params(color="white")
-    plt.setp(cbar.ax.get_yticklabels(), color="white")
-
     for spine in ax.spines.values():
         spine.set_color("#7f8c8d")
 
+    legend = ax.legend(loc="upper left", bbox_to_anchor=(1.02, 1.0), frameon=False, fontsize=8)
+    for text in legend.get_texts():
+        text.set_color("white")
+
+    ax.grid(True, color="#3b3f4a", alpha=0.4, linewidth=0.7)
     ax.tick_params(colors="white")
     fig.tight_layout()
     fig.savefig(output_path, facecolor=fig.get_facecolor(), bbox_inches="tight")
     plt.close(fig)
 
 
-def generate_historical_heatmap(
+def generate_historical_line_chart(
     session: Session,
     *,
     source_name: str = MAIN_LIVE_SOURCE_NAME,
@@ -275,12 +282,16 @@ def generate_historical_heatmap(
         to_date=to_date,
         source_name=source_name,
     )
-    dates = _build_dates(start_date=date_range.start_date, end_date=date_range.end_date)
     rows = query_daily_latest_scores(
         session=session,
         start_date=date_range.start_date,
         end_date=date_range.end_date,
         source_name=source_name,
+    )
+    dates = _effective_chart_dates(
+        rows,
+        fallback_start=date_range.start_date,
+        fallback_end=date_range.end_date,
     )
 
     matrix, vpn_names = _matrix_from_rows(rows=rows, dates=dates, top_n=top_n)
@@ -291,7 +302,7 @@ def generate_historical_heatmap(
         end_date=date_range.end_date,
     )
 
-    _render_heatmap(
+    _render_line_chart(
         matrix=matrix,
         vpn_names=vpn_names,
         dates=dates,
@@ -301,7 +312,7 @@ def generate_historical_heatmap(
 
     chart = GeneratedChart(
         chart_date=date_range.end_date,
-        chart_type=HEATMAP_CHART_TYPE,
+        chart_type=LINE_CHART_TYPE,
         file_path=str(output_path),
     )
     session.add(chart)
@@ -317,3 +328,6 @@ def generate_historical_heatmap(
         day_count=len(dates),
         chart_id=chart.id,
     )
+
+
+generate_historical_heatmap = generate_historical_line_chart

--- a/src/vpn_rating_watcher/cli.py
+++ b/src/vpn_rating_watcher/cli.py
@@ -7,7 +7,10 @@ from datetime import date
 import typer
 
 from vpn_rating_watcher.bot.runner import run_polling
-from vpn_rating_watcher.charts.service import MAIN_LIVE_SOURCE_NAME, generate_historical_heatmap
+from vpn_rating_watcher.charts.service import (
+    MAIN_LIVE_SOURCE_NAME,
+    generate_historical_line_chart,
+)
 from vpn_rating_watcher.core.settings import get_settings
 from vpn_rating_watcher.db.persistence import get_latest_snapshot_summary, persist_scrape_result
 from vpn_rating_watcher.db.session import get_session_factory
@@ -185,7 +188,7 @@ def generate_chart_command(
         None, "--output", help="Custom output file path for PNG."
     ),
 ) -> None:
-    """Generate historical heatmap PNG and persist chart metadata."""
+    """Generate historical score line chart PNG and persist chart metadata."""
     try:
         from_date = _parse_iso_date(from_date_raw, "--from")
         to_date = _parse_iso_date(to_date_raw, "--to")
@@ -196,7 +199,7 @@ def generate_chart_command(
     session_factory = get_session_factory()
     with session_factory() as session:
         try:
-            result = generate_historical_heatmap(
+            result = generate_historical_line_chart(
                 session=session,
                 source_name=source_name,
                 days=days,

--- a/tests/test_bot_service.py
+++ b/tests/test_bot_service.py
@@ -12,7 +12,7 @@ from vpn_rating_watcher.bot.service import (
     get_today_or_latest_chart,
     upsert_telegram_chat,
 )
-from vpn_rating_watcher.charts.service import HEATMAP_CHART_TYPE
+from vpn_rating_watcher.charts.service import LINE_CHART_TYPE
 from vpn_rating_watcher.db.base import Base
 from vpn_rating_watcher.db.models import (
     GeneratedChart,
@@ -46,12 +46,12 @@ def test_get_today_or_latest_chart_prefers_today() -> None:
     with _session() as session:
         older = GeneratedChart(
             chart_date=date(2026, 3, 28),
-            chart_type=HEATMAP_CHART_TYPE,
+            chart_type=LINE_CHART_TYPE,
             file_path="artifacts/charts/older.png",
         )
         today = GeneratedChart(
             chart_date=date(2026, 3, 29),
-            chart_type=HEATMAP_CHART_TYPE,
+            chart_type=LINE_CHART_TYPE,
             file_path="artifacts/charts/today.png",
         )
         session.add_all([older, today])
@@ -66,12 +66,12 @@ def test_get_today_or_latest_chart_falls_back_to_latest() -> None:
     with _session() as session:
         older = GeneratedChart(
             chart_date=date(2026, 3, 28),
-            chart_type=HEATMAP_CHART_TYPE,
+            chart_type=LINE_CHART_TYPE,
             file_path="artifacts/charts/older.png",
         )
         newest = GeneratedChart(
             chart_date=date(2026, 3, 29),
-            chart_type=HEATMAP_CHART_TYPE,
+            chart_type=LINE_CHART_TYPE,
             file_path="artifacts/charts/newest.png",
         )
         session.add_all([older, newest])

--- a/tests/test_chart_aggregation.py
+++ b/tests/test_chart_aggregation.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 from datetime import date, datetime, timezone
 
+import numpy as np
 from sqlalchemy import create_engine
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Session
 
-from vpn_rating_watcher.charts.service import query_daily_latest_scores
+from vpn_rating_watcher.charts.service import (
+    DailyScoreRow,
+    _effective_chart_dates,
+    _matrix_from_rows,
+    query_daily_latest_scores,
+)
 from vpn_rating_watcher.db.base import Base
 from vpn_rating_watcher.db.models import Snapshot, Vpn, VpnSnapshotResult
 
@@ -198,3 +204,37 @@ def test_query_daily_latest_scores_binds_date_params_for_postgresql() -> None:
     assert end in date_params
     assert start.isoformat() not in compiled.params.values()
     assert end.isoformat() not in compiled.params.values()
+
+
+def test_effective_chart_dates_start_at_first_data_date() -> None:
+    rows = [
+        DailyScoreRow(vpn_name="VPN A", snapshot_date=date(2026, 3, 10), score=30),
+        DailyScoreRow(vpn_name="VPN A", snapshot_date=date(2026, 3, 12), score=31),
+    ]
+
+    dates = _effective_chart_dates(
+        rows=rows,
+        fallback_start=date(2026, 3, 1),
+        fallback_end=date(2026, 3, 30),
+    )
+
+    assert dates[0] == date(2026, 3, 10)
+    assert dates[-1] == date(2026, 3, 12)
+
+
+def test_matrix_from_rows_keeps_missing_dates_as_gaps() -> None:
+    dates = [date(2026, 3, 10), date(2026, 3, 11), date(2026, 3, 12)]
+    rows = [
+        DailyScoreRow(vpn_name="VPN A", snapshot_date=date(2026, 3, 10), score=30),
+        DailyScoreRow(vpn_name="VPN A", snapshot_date=date(2026, 3, 12), score=31),
+        DailyScoreRow(vpn_name="VPN B", snapshot_date=date(2026, 3, 10), score=35),
+        DailyScoreRow(vpn_name="VPN B", snapshot_date=date(2026, 3, 11), score=36),
+        DailyScoreRow(vpn_name="VPN B", snapshot_date=date(2026, 3, 12), score=34),
+    ]
+
+    matrix, vpn_names = _matrix_from_rows(rows=rows, dates=dates, top_n=None)
+
+    vpn_a_idx = vpn_names.index("VPN A")
+    assert matrix[vpn_a_idx, 0] == 30
+    assert np.isnan(matrix[vpn_a_idx, 1])
+    assert matrix[vpn_a_idx, 2] == 31

--- a/tests/test_daily_telegram_post.py
+++ b/tests/test_daily_telegram_post.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
-from vpn_rating_watcher.charts.service import HEATMAP_CHART_TYPE
+from vpn_rating_watcher.charts.service import LINE_CHART_TYPE
 from vpn_rating_watcher.db.base import Base
 from vpn_rating_watcher.db.models import GeneratedChart, TelegramChat
 from vpn_rating_watcher.jobs.daily_telegram_post import (
@@ -36,7 +36,7 @@ def test_post_daily_is_idempotent_for_same_day(tmp_path: Path) -> None:
         session.add(
             GeneratedChart(
                 chart_date=date(2026, 3, 29),
-                chart_type=HEATMAP_CHART_TYPE,
+                chart_type=LINE_CHART_TYPE,
                 file_path=str(chart_path),
             )
         )
@@ -79,7 +79,7 @@ def test_post_daily_skips_inactive_chats(tmp_path: Path) -> None:
         session.add(
             GeneratedChart(
                 chart_date=date(2026, 3, 29),
-                chart_type=HEATMAP_CHART_TYPE,
+                chart_type=LINE_CHART_TYPE,
                 file_path=str(chart_path),
             )
         )


### PR DESCRIPTION
### Motivation
- Replace the historical heatmap visualization with a standard multi-line time series so each VPN has its own line and missing dates are rendered as gaps.
- Keep existing daily aggregation/query logic and source semantics (`maximkatz`, `csv_backfill`, `mixed`) while preserving PNG output and bot delivery flow.

### Description
- Implemented a line-chart renderer (`_render_line_chart`) and a new chart type constant `LINE_CHART_TYPE = "historical_line_chart"` and switched output filename prefix to `linechart_...png`.
- Added `_effective_chart_dates` to start the rendered x-axis at the first date that has data in the selected dataset and keep a fallback to the requested range when no rows exist.
- Reused `query_daily_latest_scores` and data aggregation; building a matrix with `NaN` for missing dates so plotted series show gaps instead of zeros.
- Updated CLI to call `generate_historical_line_chart` and preserved `generate_historical_heatmap` as an alias; updated bot chart lookup to use `LINE_CHART_TYPE`; updated README usage text.
- Updated tests to use the new chart type constant and added unit tests for effective-chart-date behavior and that missing dates remain `NaN` gaps.

### Testing
- Ran `ruff check .` which passed (code linting/formatting checks succeeded).
- Ran `pytest -q` in this environment but test collection failed due to missing runtime/test dependencies (`sqlalchemy`, `numpy`, `pydantic`, `typer`, `playwright`), so the full test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9da04e5e8832ebc25b67005f7a788)